### PR TITLE
ov5640: camera support for QVGA, 720p and 1080p

### DIFF
--- a/examples/camera_streaming_http/camera_streaming_http.cc
+++ b/examples/camera_streaming_http/camera_streaming_http.cc
@@ -23,6 +23,7 @@
 #include "libs/libjpeg/jpeg.h"
 #include "third_party/freertos_kernel/include/FreeRTOS.h"
 #include "third_party/freertos_kernel/include/task.h"
+#include "libs/base/gpio.h"
 
 #if defined(CAMERA_STREAMING_HTTP_ETHERNET)
 #include "libs/base/ethernet.h"
@@ -39,12 +40,18 @@ namespace {
 
 constexpr char kIndexFileName[] = "/coral_micro_camera.html";
 constexpr char kCameraStreamUrlPrefix[] = "/camera_stream";
+constexpr float kRedCoefficient = .2126;
+constexpr float kGreenCoefficient = .7152;
+constexpr float kBlueCoefficient = .0722;
+constexpr float kUint8Max = 255.0;
 
 HttpServer::Content UriHandler(const char* uri) {
+  // printf("HTTP url: %s\n", uri);
   if (StrEndsWith(uri, "index.shtml") ||
       StrEndsWith(uri, "coral_micro_camera.html")) {
     return std::string(kIndexFileName);
-  } else if (StrEndsWith(uri, kCameraStreamUrlPrefix)) {
+  } else if (StrEndsWith(uri, kCameraStreamUrlPrefix))
+  {
     // [start-snippet:jpeg]
     std::vector<uint8_t> buf(CameraTask::kWidth * CameraTask::kHeight *
                              CameraFormatBpp(CameraFormat::kRgb));
@@ -52,15 +59,18 @@ HttpServer::Content UriHandler(const char* uri) {
         CameraFormat::kRgb,       CameraFilterMethod::kBilinear,
         CameraRotation::k0,       CameraTask::kWidth,
         CameraTask::kHeight,
-        /*preserve_ratio=*/false, buf.data(),
+        /*preserve_ratio=*/false, (uint8_t *)buf.data(),
         /*while_balance=*/true};
+
+    // CameraTask::GetSingleton()->SetTestPattern(CameraTestPattern::kColorBar);
+
     if (!CameraTask::GetSingleton()->GetFrame({fmt})) {
       printf("Unable to get frame from camera\r\n");
       return {};
     }
 
     std::vector<uint8_t> jpeg;
-    JpegCompressRgb(buf.data(), fmt.width, fmt.height, /*quality=*/75, &jpeg);
+    JpegCompressRgb((uint8_t *)buf.data(), fmt.width, fmt.height, /*quality=*/75, &jpeg);
     // [end-snippet:jpeg]
     return jpeg;
   }
@@ -74,6 +84,12 @@ void Main() {
 
   CameraTask::GetSingleton()->SetPower(true);
   CameraTask::GetSingleton()->Enable(CameraMode::kStreaming);
+
+  // Register callback for the user button.
+  GpioConfigureInterrupt(
+      coralmicro::Gpio::kUserButton, coralmicro::GpioInterruptMode::kIntModeFalling,
+      [handle = xTaskGetCurrentTaskHandle()]() { xTaskResumeFromISR(handle); },
+      /*debounce_interval_us=*/50 * 1e3);
 
 #if defined(CAMERA_STREAMING_HTTP_ETHERNET)
   EthernetInit(/*default_iface=*/false);
@@ -106,7 +122,7 @@ void Main() {
 #else   // USB
   std::string usb_ip;
   if (GetUsbIpAddress(&usb_ip)) {
-    printf("Serving on: http://%s\r\n", usb_ip.c_str());
+    printf("Serving on---: http://%s\r\n", usb_ip.c_str());
   }
 #endif  // defined(CAMERA_STREAMING_HTTP_ETHERNET)
 
@@ -114,7 +130,10 @@ void Main() {
   http_server.AddUriHandler(UriHandler);
   UseHttpServer(&http_server);
 
-  vTaskSuspend(nullptr);
+  while (true) {
+    vTaskSuspend(nullptr);
+    CameraTask::GetSingleton()->ChangePattern();
+  }
 }
 }  // namespace
 }  // namespace coralmicro

--- a/examples/camera_streaming_http/web/coral_micro_camera.html
+++ b/examples/camera_streaming_http/web/coral_micro_camera.html
@@ -38,8 +38,6 @@
                             imgElt.src = imgReader.result;
                             imgElt.width = document.getElementById("image-width").value;
                             imgElt.height = document.getElementById("image-height").value;
-                            let rotation = document.getElementById("image-rotation").value;
-                            imgElt.style.transform = 'rotate(' + rotation.toString() + 'deg)';
                         };
                     })
                     .catch((reason => {
@@ -95,15 +93,15 @@
     <div id="setting-menu">
         <div style="margin-top: 10px"></div>
         <label for="image-width" class="input-label">Image Width:</label>
-        <input id="image-width" type="number" required value=500>
+        <input id="image-width" type="number" required value=1280>
         <label for="image-height" class="input-label">Image Height:</label>
-        <input id="image-height" type="number" required value=500>
+        <input id="image-height" type="number" required value=720>
         <label for="image-rotation" class="input-label">Rotation:</label>
         <select name="image-rotation" id="image-rotation">
-            <option value=0>0</option>
+            <option value=0 selected>0</option>
             <option value=90>90</option>
             <option value=180>180</option>
-            <option value=270 selected>270</option>
+            <option value=270>0</option>
         </select>
     </div>
     <img id="coral-micro-camera-image"

--- a/examples/gpio/gpio.cc
+++ b/examples/gpio/gpio.cc
@@ -36,8 +36,11 @@ namespace {
   LedSet(Led::kStatus, true);
 
   constexpr Gpio kGpiosToTest[] = {
-      kSpiCs, kSpiSck, kSpiSdo,  kSpiSdi,  kSda6, kScl1, kSda1,
-      kAA,    kAB,     kUartCts, kUartRts, kPwm1, kPwm0, kScl6,
+      kSpiCs, kSpiSck, kSpiSdo,  kSpiSdi,
+      //kSda6,
+      kScl1, kSda1,
+      kAA,    kAB,     kUartCts, kUartRts, kPwm1, kPwm0,
+      //kScl6,
   };
 
   for (auto gpio : kGpiosToTest) {

--- a/libs/base/gpio.cc
+++ b/libs/base/gpio.cc
@@ -45,11 +45,14 @@ GPIO_Type* PinNameToModule[Gpio::kCount] = {
     [Gpio::kCryptoRst] = GPIO12,   [Gpio::kLpuart1SwitchEnable] = GPIO9,
     [Gpio::kSpiCs] = GPIO6,        [Gpio::kSpiSck] = GPIO6,
     [Gpio::kSpiSdo] = GPIO6,       [Gpio::kSpiSdi] = GPIO6,
-    [Gpio::kSda6] = GPIO6,         [Gpio::kScl1] = GPIO3,
+    // [Gpio::kSda6] = GPIO6,
+    [Gpio::kScl1] = GPIO3,
     [Gpio::kSda1] = GPIO4,         [Gpio::kAA] = GPIO3,
     [Gpio::kAB] = GPIO3,           [Gpio::kUartCts] = GPIO2,
     [Gpio::kUartRts] = GPIO2,      [Gpio::kPwm1] = GPIO3,
-    [Gpio::kPwm0] = GPIO2,         [Gpio::kScl6] = GPIO6,
+    [Gpio::kPwm0] = GPIO2,
+    // [Gpio::kScl6] = GPIO6,
+    [Gpio::kCamPwrDn] = GPIO5,     [Gpio::kCamReset] = GPIO3,
 };
 
 constexpr uint32_t PinNameToPin[Gpio::kCount] = {
@@ -73,7 +76,7 @@ constexpr uint32_t PinNameToPin[Gpio::kCount] = {
     [Gpio::kSpiSck] = 10,
     [Gpio::kSpiSdo] = 11,
     [Gpio::kSpiSdi] = 12,
-    [Gpio::kSda6] = 6,
+    // [Gpio::kSda6] = 6,
     [Gpio::kScl1] = 31,
     [Gpio::kSda1] = 0,
     [Gpio::kAA] = 5,
@@ -82,7 +85,9 @@ constexpr uint32_t PinNameToPin[Gpio::kCount] = {
     [Gpio::kUartRts] = 11,
     [Gpio::kPwm1] = 0,
     [Gpio::kPwm0] = 31,
-    [Gpio::kScl6] = 7,
+    // [Gpio::kScl6] = 7,
+    [Gpio::kCamPwrDn] = 10,
+    [Gpio::kCamReset] = 25,
 };
 
 gpio_pin_config_t PinNameToConfig[Gpio::kCount] = {
@@ -206,12 +211,12 @@ gpio_pin_config_t PinNameToConfig[Gpio::kCount] = {
             .outputLogic = 0,
             .interruptMode = kGPIO_NoIntmode,
         },
-    [Gpio::kSda6] =
-        {
-            .direction = kGPIO_DigitalInput,
-            .outputLogic = 0,
-            .interruptMode = kGPIO_NoIntmode,
-        },
+    // [Gpio::kSda6] =
+    //     {
+    //         .direction = kGPIO_DigitalInput,
+    //         .outputLogic = 0,
+    //         .interruptMode = kGPIO_NoIntmode,
+    //     },
     [Gpio::kScl1] =
         {
             .direction = kGPIO_DigitalInput,
@@ -260,10 +265,22 @@ gpio_pin_config_t PinNameToConfig[Gpio::kCount] = {
             .outputLogic = 0,
             .interruptMode = kGPIO_NoIntmode,
         },
-    [Gpio::kScl6] =
+    // [Gpio::kScl6] =
+    //     {
+    //         .direction = kGPIO_DigitalInput,
+    //         .outputLogic = 0,
+    //         .interruptMode = kGPIO_NoIntmode,
+    //     },
+    [Gpio::kCamPwrDn] =
         {
-            .direction = kGPIO_DigitalInput,
-            .outputLogic = 0,
+            .direction = kGPIO_DigitalOutput,
+            .outputLogic = 1,
+            .interruptMode = kGPIO_NoIntmode,
+        },
+    [Gpio::kCamReset] =
+        {
+            .direction = kGPIO_DigitalOutput,
+            .outputLogic = 1,
             .interruptMode = kGPIO_NoIntmode,
         },
 };
@@ -289,7 +306,7 @@ constexpr IRQn_Type PinNameToIRQ[Gpio::kCount] = {
     [Gpio::kSpiSck] = GPIO6_Combined_0_15_IRQn,
     [Gpio::kSpiSdo] = GPIO6_Combined_0_15_IRQn,
     [Gpio::kSpiSdi] = GPIO6_Combined_0_15_IRQn,
-    [Gpio::kSda6] = GPIO6_Combined_0_15_IRQn,
+    // [Gpio::kSda6] = GPIO6_Combined_0_15_IRQn,
     [Gpio::kScl1] = GPIO3_Combined_16_31_IRQn,
     [Gpio::kSda1] = GPIO4_Combined_0_15_IRQn,
     [Gpio::kAA] = GPIO3_Combined_0_15_IRQn,
@@ -298,7 +315,7 @@ constexpr IRQn_Type PinNameToIRQ[Gpio::kCount] = {
     [Gpio::kUartRts] = GPIO2_Combined_0_15_IRQn,
     [Gpio::kPwm1] = GPIO3_Combined_0_15_IRQn,
     [Gpio::kPwm0] = GPIO2_Combined_16_31_IRQn,
-    [Gpio::kScl6] = GPIO6_Combined_0_15_IRQn,
+    // [Gpio::kScl6] = GPIO6_Combined_0_15_IRQn,
 };
 
 constexpr uint32_t PinNameToIOMUXC[Gpio::kCount][5] = {
@@ -322,7 +339,7 @@ constexpr uint32_t PinNameToIOMUXC[Gpio::kCount][5] = {
     [Gpio::kSpiSck] = {IOMUXC_GPIO_LPSR_10_GPIO_MUX6_IO10},
     [Gpio::kSpiSdo] = {IOMUXC_GPIO_LPSR_11_GPIO_MUX6_IO11},
     [Gpio::kSpiSdi] = {IOMUXC_GPIO_LPSR_12_GPIO_MUX6_IO12},
-    [Gpio::kSda6] = {IOMUXC_GPIO_LPSR_06_GPIO_MUX6_IO06},
+    // [Gpio::kSda6] = {IOMUXC_GPIO_LPSR_06_GPIO_MUX6_IO06},
     [Gpio::kScl1] = {IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31},
     [Gpio::kSda1] = {IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00},
     [Gpio::kAA] = {IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05},
@@ -331,7 +348,9 @@ constexpr uint32_t PinNameToIOMUXC[Gpio::kCount][5] = {
     [Gpio::kUartRts] = {IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11},
     [Gpio::kPwm1] = {IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00},
     [Gpio::kPwm0] = {IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31},
-    [Gpio::kScl6] = {IOMUXC_GPIO_LPSR_07_GPIO_MUX6_IO07},
+    // [Gpio::kScl6] = {IOMUXC_GPIO_LPSR_07_GPIO_MUX6_IO07},
+    [Gpio::kCamPwrDn] = {IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10},
+    [Gpio::kCamReset] = {IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25},
 };
 
 constexpr uint32_t PinNameToPullMask[Gpio::kCount] = {
@@ -355,7 +374,7 @@ constexpr uint32_t PinNameToPullMask[Gpio::kCount] = {
     [Gpio::kSpiSck] = 0x0000000C,
     [Gpio::kSpiSdo] = 0x0000000C,
     [Gpio::kSpiSdi] = 0x0000000C,
-    [Gpio::kSda6] = 0x0000000C,
+    // [Gpio::kSda6] = 0x0000000C,
     [Gpio::kScl1] = 0x0000000C,
     [Gpio::kSda1] = 0x0000000C,
     [Gpio::kAA] = 0x0000000C,
@@ -364,7 +383,9 @@ constexpr uint32_t PinNameToPullMask[Gpio::kCount] = {
     [Gpio::kUartRts] = 0x0000000C,
     [Gpio::kPwm1] = 0x0000000C,
     [Gpio::kPwm0] = 0x0000000C,
-    [Gpio::kScl6] = 0x0000000C,
+    // [Gpio::kScl6] = 0x0000000C,
+    [Gpio::kCamPwrDn] = 0x0000000C,
+    [Gpio::kCamReset] = 0x0000000C,
 };
 
 constexpr uint32_t PinNameToNoPull[Gpio::kCount] = {
@@ -388,7 +409,7 @@ constexpr uint32_t PinNameToNoPull[Gpio::kCount] = {
     [Gpio::kSpiSck] = 0x00000000,
     [Gpio::kSpiSdo] = 0x00000000,
     [Gpio::kSpiSdi] = 0x00000000,
-    [Gpio::kSda6] = 0x00000000,
+    // [Gpio::kSda6] = 0x00000000,
     [Gpio::kScl1] = 0x00000000,
     [Gpio::kSda1] = 0x00000000,
     [Gpio::kAA] = 0x00000000,
@@ -397,7 +418,9 @@ constexpr uint32_t PinNameToNoPull[Gpio::kCount] = {
     [Gpio::kUartRts] = 0x0000000C,
     [Gpio::kPwm1] = 0x00000000,
     [Gpio::kPwm0] = 0x00000000,
-    [Gpio::kScl6] = 0x00000000,
+    // [Gpio::kScl6] = 0x00000000,
+    [Gpio::kCamPwrDn] = 0x00000000,
+    [Gpio::kCamReset] = 0x00000000,
 };
 
 constexpr uint32_t PinNameToPullUp[Gpio::kCount] = {
@@ -421,7 +444,7 @@ constexpr uint32_t PinNameToPullUp[Gpio::kCount] = {
     [Gpio::kSpiSck] = 0x00000000,
     [Gpio::kSpiSdo] = 0x00000000,
     [Gpio::kSpiSdi] = 0x00000000,
-    [Gpio::kSda6] = 0x0000000C,
+    // [Gpio::kSda6] = 0x0000000C,
     [Gpio::kScl1] = 0x0000000C,
     [Gpio::kSda1] = 0x0000000C,
     [Gpio::kAA] = 0x0000000C,
@@ -430,7 +453,9 @@ constexpr uint32_t PinNameToPullUp[Gpio::kCount] = {
     [Gpio::kUartRts] = 0x00000004,
     [Gpio::kPwm1] = 0x0000000C,
     [Gpio::kPwm0] = 0x0000000C,
-    [Gpio::kScl6] = 0x0000000C,
+    // [Gpio::kScl6] = 0x0000000C,
+    [Gpio::kCamPwrDn] = 0x0000000C,
+    [Gpio::kCamReset] = 0x0000000C,
 };
 
 constexpr uint32_t PinNameToPullDown[Gpio::kCount] = {
@@ -454,7 +479,7 @@ constexpr uint32_t PinNameToPullDown[Gpio::kCount] = {
     [Gpio::kSpiSck] = 0x00000004,
     [Gpio::kSpiSdo] = 0x00000004,
     [Gpio::kSpiSdi] = 0x00000004,
-    [Gpio::kSda6] = 0x00000004,
+    // [Gpio::kSda6] = 0x00000004,
     [Gpio::kScl1] = 0x00000004,
     [Gpio::kSda1] = 0x00000004,
     [Gpio::kAA] = 0x00000004,
@@ -463,7 +488,9 @@ constexpr uint32_t PinNameToPullDown[Gpio::kCount] = {
     [Gpio::kUartRts] = 0x00000008,
     [Gpio::kPwm1] = 0x00000004,
     [Gpio::kPwm0] = 0x00000004,
-    [Gpio::kScl6] = 0x00000004,
+    // [Gpio::kScl6] = 0x00000004,
+    [Gpio::kCamPwrDn] = 0x00000004,
+    [Gpio::kCamReset] = 0x00000004,
 };
 
 constexpr gpio_interrupt_mode_t

--- a/libs/base/gpio.h
+++ b/libs/base/gpio.h
@@ -67,7 +67,7 @@ enum Gpio {
   // SPI6_SDI (GPIO_LPSR_12); right header (J10); pin 8
   kSpiSdi,
   // I2C6_SDA (GPIO_LPSR_06); right header (J10); pin 10
-  kSda6,
+  // kSda6,
   // I2C1_SCL (GPIO_AD_32); right header (J10); pin 11
   kScl1,
   // I2C1_SDA (GPIO_AD_33); right header (J10); pin 12
@@ -85,15 +85,19 @@ enum Gpio {
   // PWM_A (GPIO_AD_00); left header (J9), pin 10
   kPwm0,
   // I2C6_SCL (GPIO_LPSR_07); left header (J9), pin 11
-  kScl6,
+  // kScl6,
+  // GPIO_DISP_B2_09 - PWDN - camera
+  kCamPwrDn,
+  // GPIO_AD_26 - Reset - Camera
+  kCamReset,
   // Number of pre-configured GPIOs
   kCount,
 
   // @cond Do not generate docs
-  kArduinoD0 = kScl6,
+  // kArduinoD0 = kScl6,
   kArduinoD1 = kUartRts,
   kArduinoD2 = kUartCts,
-  kArduinoD3 = kSda6,
+  // kArduinoD3 = kSda6,
   kArduinoA0 = kAB,
   kArduinoA1 = kAA,
   kArduinoA3 = kPwm0,

--- a/libs/base/main_freertos_m7.cc
+++ b/libs/base/main_freertos_m7.cc
@@ -46,6 +46,7 @@
 
 namespace {
 lpi2c_rtos_handle_t g_i2c5_handle;
+lpi2c_rtos_handle_t g_i2c6_handle;
 coralmicro::CdcEem g_cdc_eem;
 
 void InitializeCDCEEM() {
@@ -71,6 +72,22 @@ extern "C" int main(int argc, char** argv) {
   return real_main(argc, argv, true, true);
 }
 
+static inline void IOMUXC_SetPinMux(uint32_t muxRegister,
+                                    uint32_t muxMode,
+                                    uint32_t inputRegister,
+                                    uint32_t inputDaisy,
+                                    uint32_t configRegister,
+                                    uint32_t inputOnfield)
+{
+    *((volatile uint32_t *)muxRegister) =
+        IOMUXC_SW_MUX_CTL_PAD_MUX_MODE(muxMode) | IOMUXC_SW_MUX_CTL_PAD_SION(inputOnfield);
+
+    if (inputRegister != 0UL)
+    {
+        *((volatile uint32_t *)inputRegister) = inputDaisy;
+    }
+}
+
 extern "C" int real_main(int argc, char** argv, bool init_console_tx,
                          bool init_console_rx) {
   BOARD_InitHardware(true);
@@ -81,6 +98,7 @@ extern "C" int real_main(int argc, char** argv, bool init_console_tx,
   coralmicro::IpcM7::GetSingleton()->Init();
   coralmicro::RandomInit();
   coralmicro::ConsoleM7::GetSingleton()->Init(init_console_tx, init_console_rx);
+
   CHECK(coralmicro::LfsInit());
   // Make sure this happens before EEM or WICED are initialized.
   tcpip_init(nullptr, nullptr);
@@ -92,6 +110,8 @@ extern "C" int real_main(int argc, char** argv, bool init_console_tx,
   coralmicro::EdgeTpuTask::GetSingleton()->Init();
   coralmicro::TempSensorInit();
 
+  printf("!!!! START %s %s!!!\n", __DATE__, __TIME__);
+
   // Initialize I2C5 state
   NVIC_SetPriority(LPI2C5_IRQn, 3);
   lpi2c_master_config_t config;
@@ -99,8 +119,25 @@ extern "C" int real_main(int argc, char** argv, bool init_console_tx,
   LPI2C_RTOS_Init(&g_i2c5_handle, reinterpret_cast<LPI2C_Type*>(LPI2C5_BASE),
                   &config, CLOCK_GetFreq(kCLOCK_OscRc48MDiv2));
 
+  // Initialize I2C6 state
+#define IOMUXC_GPIO_LPSR_07_LPI2C6_SCL 0x40C0801CU, 0x0U, 0x40C0808CU, 0x0U, 0x40C0805CU
+#define IOMUXC_GPIO_LPSR_06_LPI2C6_SDA 0x40C08018U, 0x0U, 0x40C08090U, 0x0U, 0x40C08058U
+
+  IOMUXC_SetPinMux(
+      IOMUXC_GPIO_LPSR_06_LPI2C6_SDA,         /* GPIO_LPSR_06 is configured as LPI2C6_SDA */
+      1U);                                    /* Software Input On Field: Force input path of pad GPIO_LPSR_06 */
+  IOMUXC_SetPinMux(
+      IOMUXC_GPIO_LPSR_07_LPI2C6_SCL,         /* GPIO_LPSR_07 is configured as LPI2C6_SCL */
+      1U);                                    /* Software Input On Field: Force input path of pad GPIO_LPSR_07 */
+
+  NVIC_SetPriority(LPI2C6_IRQn, 3);
+  lpi2c_master_config_t config6;
+  LPI2C_MasterGetDefaultConfig(&config6);
+  LPI2C_RTOS_Init(&g_i2c6_handle, reinterpret_cast<LPI2C_Type*>(LPI2C6_BASE),
+                  &config6, CLOCK_GetFreq(kCLOCK_OscRc48MDiv2));
+
   coralmicro::PmicTask::GetSingleton()->Init(&g_i2c5_handle);
-  coralmicro::CameraTask::GetSingleton()->Init(&g_i2c5_handle);
+  coralmicro::CameraTask::GetSingleton()->Init(&g_i2c5_handle, &g_i2c6_handle);
 
   CHECK(xTaskCreate(app_main, "app_main", configMINIMAL_STACK_SIZE * 30,
                     nullptr, coralmicro::kAppTaskPriority, nullptr) == pdPASS);

--- a/libs/camera/CMakeLists.txt
+++ b/libs/camera/CMakeLists.txt
@@ -14,16 +14,23 @@
 
 add_library_m7(libs_camera_freertos STATIC
     camera.cc
+    camera_support.c
 )
+
 target_link_libraries(libs_camera_freertos
     libs_base-m7_freertos
     libs_pmic_freertos
+    ${libs_nxp_rt1176-sdk_TARGET_LINK_LIBRARIES}
 )
 
 add_library_m4(libs_camera_freertos-m4 STATIC
     camera.cc
+    camera_support.c
 )
 target_link_libraries(libs_camera_freertos-m4
     libs_base-m4_freertos
     libs_pmic_freertos-m4
+    ${libs_nxp_rt1176-sdk_TARGET_LINK_LIBRARIES}
 )
+
+

--- a/libs/camera/camera.cc
+++ b/libs/camera/camera.cc
@@ -16,12 +16,50 @@
 
 #include "libs/camera/camera.h"
 
+#include "camera.h"
 #include "libs/base/check.h"
 #include "libs/base/gpio.h"
 #include "libs/pmic/pmic.h"
 #include "third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/fsl_csi.h"
 #include "third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/fsl_lpi2c.h"
 #include "third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/fsl_lpi2c_freertos.h"
+
+#include "fsl_gpio.h"
+#include "fsl_csi.h"
+#include "fsl_mipi_csi2rx.h"
+#include "fsl_camera.h"
+#include "fsl_camera_receiver.h"
+#include "fsl_camera_device.h"
+#include "fsl_csi_camera_adapter.h"
+#include "fsl_ov5640.h"
+#include "fsl_pxp.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+#ifdef CPU_MIMXRT1176CVM8A_cm4
+#undef DEMO_CAMERA_BUFFER_COUNT
+#define DEMO_CAMERA_BUFFER_COUNT 1
+
+#undef DEMO_CAMERA_BUFFER_BPP
+#define DEMO_CAMERA_BUFFER_BPP 1
+#endif
+
+#define DBG_OUTPUT(...)  printf(__VA_ARGS__)
+// #define DBG_OUTPUT(...)
+
+// #define DEBUG_LINE()  printf("D:%s:%d\n", __FILE__, __LINE__)
+
+#ifdef CPU_MIMXRT1176CVM8A_cm4
+uint8_t pxp_buffer[1];
+#else
+// __attribute__((section("NonCacheableCamera,\"aw\",%nobits @")))
+// __attribute__((aligned(DEMO_CAMERA_BUFFER_ALIGN)))
+// uint8_t
+//     pxp_buffer[DEMO_CAMERA_HEIGHT][(DEMO_CAMERA_WIDTH + LINE_PADDING) * 3];
+uint8_t pxp_buffer[1];
+#endif
 
 #if (__CORTEX_M == 7)
 #include "third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/cm7/fsl_cache.h"
@@ -32,100 +70,76 @@
 #include <cstring>
 #include <memory>
 
+status_t BOARD_Camera_I2C_SendSCCB(
+    uint8_t deviceAddress, uint32_t subAddress, uint8_t subAddressSize, const uint8_t *txBuff, uint8_t txBuffSize)
+{
+  return coralmicro::CameraTask::GetSingleton()->Write(
+        subAddress, txBuff, txBuffSize) ? kStatus_Success : !kStatus_Success;
+}
+
+status_t BOARD_Camera_I2C_ReceiveSCCB(
+    uint8_t deviceAddress, uint32_t subAddress, uint8_t subAddressSize, uint8_t *rxBuff, uint8_t rxBuffSize)
+{
+  return coralmicro::CameraTask::GetSingleton()->Read(subAddress, &rxBuff[0]) ? kStatus_Success : !kStatus_Success;
+}
+
+void BOARD_PullCameraResetPin(bool pullUp)
+{
+  printf("BOARD_PullCameraResetPin:%d\n", pullUp);
+  coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kCamReset, pullUp);
+}
+
+void BOARD_PullCameraPowerDownPin(bool pullUp)
+{
+  printf("BOARD_PullCameraPowerDownPin:%d\n", pullUp);
+  coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kCamPwrDn, pullUp);
+}
+
 namespace coralmicro {
 namespace {
-constexpr uint8_t kCameraAddress = 0x24;
-constexpr int kFramebufferCount = 4;
+constexpr uint8_t kCameraAddress = 0x3c;
+constexpr int kFramebufferCount = DEMO_CAMERA_BUFFER_COUNT;
+constexpr uint8_t kModelIdHExpected = 0x56;
+constexpr uint8_t kModelIdLExpected = 0x40;
+
 constexpr float kRedCoefficient = .2126;
 constexpr float kGreenCoefficient = .7152;
 constexpr float kBlueCoefficient = .0722;
 constexpr float kUint8Max = 255.0;
 
-constexpr uint8_t kModelIdHExpected = 0x01;
-constexpr uint8_t kModelIdLExpected = 0xB0;
-
-// CSI driver wants width to be divisible by 8, and 324 is not.
-// 324 * 324 == 13122 * 8 -- this makes the CSI driver happy!
-constexpr size_t kCsiWidth = 8;
-constexpr size_t kCsiHeight = 13122;
-
-struct CameraRegisters {
-  enum : uint16_t {
-    kModelIdH = 0x0000,
-    kModelIdL = 0x0001,
-    kModeSelect = 0x0100,
-    kSwReset = 0x0103,
-    kAnalogGain = 0x0205,
-    kDigitalGainH = 0x020E,
-    kDigitalGainL = 0x020F,
-    kDgainControl = 0x0350,
-    kTestPatternMode = 0x0601,
-    kBlcCfg = 0x1000,
-    kBlcDither = 0x1001,
-    kBlcDarkpixel = 0x1002,
-    kBlcTgt = 0x1003,
-    kBliEn = 0x1006,
-    kBlc2Tgt = 0x1007,
-    kDpcCtrl = 0x1008,
-    kClusterThrHot = 0x1009,
-    kClusterThrCold = 0x100A,
-    kSingleThrHot = 0x100B,
-    kSingleThrCold = 0x100C,
-    kVsyncHsyncPixelShiftEn = 0x1012,
-    kStatisticCtrl = 0x2000,
-    kMdLroiXStartH = 0x2011,
-    kMdLroiXStartL = 0x2012,
-    kMdLroiYStartH = 0x2013,
-    kMdLroiYStartL = 0x2014,
-    kMdLroiXEndH = 0x2015,
-    kMdLroiXEndL = 0x2016,
-    kMdLroiYEndH = 0x2017,
-    kMdLroiYEndL = 0x2018,
-    kAeCtrl = 0x2100,
-    kAeTargetMean = 0x2101,
-    kAeMinMean = 0x2102,
-    kConvergeInTh = 0x2103,
-    kConvergeOutTh = 0x2104,
-    kMaxIntgH = 0x2105,
-    kMaxIntgL = 0x2106,
-    kMinIntg = 0x2107,
-    kMaxAgainFull = 0x2108,
-    kMaxAgainBin2 = 0x2109,
-    kMinAgain = 0x210A,
-    kMaxDgain = 0x210B,
-    kMinDgain = 0x210C,
-    kDampingFactor = 0x210D,
-    kFsCtrl = 0x210E,
-    kFs60HzH = 0x210F,
-    kFs60HzL = 0x2110,
-    kFs50HzH = 0x2111,
-    kFs50HzL = 0x2112,
-    kMdCtrl = 0x2150,
-    kMdThl = 0x215B,
-    kI2cClear = 0x2153,
-    kBitControl = 0x3059,
-    kOscClkDiv = 0x3060,
-  };
-};
-
-__attribute__((section(".sdram_bss,\"aw\",%nobits @")))
-__attribute__((aligned(64))) uint8_t
-    framebuffers[kFramebufferCount][CameraTask::kHeight][CameraTask::kWidth];
-
-uint8_t* IndexToFramebufferPtr(int index) {
-  if (index < 0 || index >= kFramebufferCount) {
-    return nullptr;
-  }
-  return reinterpret_cast<uint8_t*>(framebuffers[index]);
-}
-
-int FramebufferPtrToIndex(const uint8_t* framebuffer_ptr) {
-  for (int i = 0; i < kFramebufferCount; ++i) {
-    if (reinterpret_cast<uint8_t*>(framebuffers[i]) == framebuffer_ptr) {
-      return i;
+static void Rgb8888ToRgb(const uint8_t* in, uint8_t* out, int width, int height, int line_padding=LINE_PADDING) {
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      // BGRA - BGR
+      out[(x * 3) + (y * width * 3) + 0] = in[(x * 4) + (y * (width + line_padding) * 4) + 0];
+      out[(x * 3) + (y * width * 3) + 1] = in[(x * 4) + (y * (width + line_padding) * 4) + 1];
+      out[(x * 3) + (y * width * 3) + 2] = in[(x * 4) + (y * (width + line_padding) * 4) + 2];
     }
   }
-  return -1;
+}
+
+static void Rgb888ToRgb(const uint8_t* in, uint8_t* out, int width, int height, int line_padding=LINE_PADDING) {
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      // BGRA - BGR
+      out[(x * 3) + (y * width * 3) + 0] = in[(x * 3) + (y * (width + line_padding) * 3) + 0];
+      out[(x * 3) + (y * width * 3) + 1] = in[(x * 3) + (y * (width + line_padding) * 3) + 1];
+      out[(x * 3) + (y * width * 3) + 2] = in[(x * 3) + (y * (width + line_padding) * 3) + 2];
+    }
+  }
+}
+
+} // namespace
+
+int CameraFormatBpp(CameraFormat fmt) {
+  switch (fmt) {
+    case CameraFormat::kRgb:
+      return 3;
+    case CameraFormat::kRaw:
+    case CameraFormat::kY8:
+      return 1;
+  }
+  return 0;
 }
 
 void ResizeNearestNeighbor(const uint8_t* src, int src_w, int src_h,
@@ -412,144 +426,40 @@ void RgbToGrayscale(const uint8_t* camera_rgb, uint8_t* camera_grayscale,
   }
 }
 
-void AutoWhiteBalance(uint8_t* camera_rgb, int width, int height) {
-  unsigned int r_sum = 0, g_sum = 0, b_sum = 0;
-  float r_sum_f = 0.0, g_sum_f = 0.0, b_sum_f = 0.0;
-  float threshold = 0.9f;
-  uint16_t threshold16 = static_cast<uint16_t>(threshold * 255);
-  uint16_t min_rgb, max_rgb;
-  for (int i = 0; i < width * height; ++i) {
-    uint8_t r = camera_rgb[i * 3 + 0];
-    uint8_t g = camera_rgb[i * 3 + 1];
-    uint8_t b = camera_rgb[i * 3 + 2];
-    min_rgb = static_cast<uint16_t>(std::min(r, std::min(g, b)));
-    max_rgb = static_cast<uint16_t>(std::max(r, std::max(g, b)));
-    if (((max_rgb - min_rgb) * 255) > (threshold16 * max_rgb)) {
-      continue;
-    }
-    r_sum += r;
-    g_sum += g;
-    b_sum += b;
-  }
-  r_sum_f = static_cast<float>(r_sum);
-  g_sum_f = static_cast<float>(g_sum);
-  b_sum_f = static_cast<float>(b_sum);
-  float max_channel = std::max(r_sum_f, std::max(g_sum_f, b_sum_f));
-  float epsilon = 0.1;
-  float r_gain_f = r_sum_f < epsilon ? 0.0f : max_channel / r_sum_f;
-  float g_gain_f = g_sum_f < epsilon ? 0.0f : max_channel / g_sum_f;
-  float b_gain_f = b_sum_f < epsilon ? 0.0f : max_channel / b_sum_f;
-  uint16_t r_gain_i = static_cast<uint16_t>(r_gain_f * (1 << 8));
-  uint16_t g_gain_i = static_cast<uint16_t>(g_gain_f * (1 << 8));
-  uint16_t b_gain_i = static_cast<uint16_t>(b_gain_f * (1 << 8));
-  for (int i = 0; i < width * height; ++i) {
-    uint8_t r = camera_rgb[i * 3 + 0];
-    uint8_t g = camera_rgb[i * 3 + 1];
-    uint8_t b = camera_rgb[i * 3 + 2];
-    camera_rgb[i * 3 + 0] = static_cast<uint8_t>(
-        std::min(255UL, (static_cast<uint32_t>(r) * r_gain_i) >> 8));
-    camera_rgb[i * 3 + 1] = static_cast<uint8_t>(
-        std::min(255UL, (static_cast<uint32_t>(g) * g_gain_i) >> 8));
-    camera_rgb[i * 3 + 2] = static_cast<uint8_t>(
-        std::min(255UL, (static_cast<uint32_t>(b) * b_gain_i) >> 8));
-  }
-}
-}  // namespace
-
-extern "C" void CSI_DriverIRQHandler(void);
-extern "C" void CSI_IRQHandler(void) {
-  CSI_DriverIRQHandler();
-  __DSB();
-}
-
-int CameraFormatBpp(CameraFormat fmt) {
-  switch (fmt) {
-    case CameraFormat::kRgb:
-      return 3;
-    case CameraFormat::kRaw:
-    case CameraFormat::kY8:
-      return 1;
-  }
-  return 0;
-}
-
 bool CameraTask::GetFrame(const std::vector<CameraFrameFormat>& fmts) {
   if (!enabled_) {
     printf("Camera is not enabled, cannot capture frame.\r\n");
     return false;
   }
-  if (mode_ == CameraMode::kTrigger && !GpioGet(Gpio::kCameraTrigger)) {
-    printf("Camera is in trigger mode but was never triggered\r\n");
-    return false;
-  }
+
+  // if (mode_ == CameraMode::kTrigger && !GpioGet(Gpio::kCameraTrigger)) {
+  //   printf("Camera is in trigger mode but was never triggered\r\n");
+  //   return false;
+  // }
 
   bool ret = true;
-  uint8_t* raw = nullptr;
-  int index = GetFrame(&raw, true);
+  static uint8_t* raw = nullptr;
+  int index = 0;
+
+  // if (raw == nullptr)
+  index = GetFrame(&raw, true);
+
   if (!raw) {
+    printf("No frame!!!\r\n");
     return false;
   }
-  if (mode_ == CameraMode::kTrigger) {
-    GpioSet(Gpio::kCameraTrigger, false);
-  }
+
+  // if (mode_ == CameraMode::kTrigger) {
+  //   GpioSet(Gpio::kCameraTrigger, false);
+  // }
 
   for (const CameraFrameFormat& fmt : fmts) {
-    switch (fmt.fmt) {
-      case CameraFormat::kRgb: {
-        if (fmt.width == kWidth && fmt.height == kHeight) {
-          BayerToRgb(raw, fmt.buffer, fmt.width, fmt.height, fmt.filter,
-                     fmt.rotation);
-          if (fmt.white_balance &&
-              GetSingleton()->test_pattern_ == CameraTestPattern::kNone) {
-            AutoWhiteBalance(fmt.buffer, fmt.width, fmt.height);
-          }
-        } else {
-          auto buffer_rgb = std::make_unique<uint8_t[]>(
-              CameraFormatBpp(CameraFormat::kRgb) * kWidth * kHeight);
-          BayerToRgb(raw, buffer_rgb.get(), kWidth, kHeight, fmt.filter,
-                     fmt.rotation);
-          if (fmt.white_balance &&
-              GetSingleton()->test_pattern_ == CameraTestPattern::kNone) {
-            AutoWhiteBalance(buffer_rgb.get(), kWidth, kHeight);
-          }
-          ResizeNearestNeighbor(buffer_rgb.get(), kWidth, kHeight, fmt.buffer,
-                                fmt.width, fmt.height,
-                                CameraFormatBpp(CameraFormat::kRgb),
-                                fmt.preserve_ratio);
-        }
-        break;
-        case CameraFormat::kY8: {
-          if (fmt.width == kWidth && fmt.height == kHeight) {
-            BayerToGrayscale(raw, fmt.buffer, kWidth, kHeight, fmt.filter,
-                             fmt.rotation);
-          } else {
-            auto buffer_rgb = std::make_unique<uint8_t[]>(
-                CameraFormatBpp(CameraFormat::kRgb) * kWidth * kHeight);
-            auto buffer_rgb_scaled = std::make_unique<uint8_t[]>(
-                CameraFormatBpp(CameraFormat::kRgb) * fmt.width * fmt.height);
-            BayerToRgb(raw, buffer_rgb.get(), kWidth, kHeight, fmt.filter,
-                       fmt.rotation);
-            ResizeNearestNeighbor(
-                buffer_rgb.get(), kWidth, kHeight, buffer_rgb_scaled.get(),
-                fmt.width, fmt.height, CameraFormatBpp(CameraFormat::kRgb),
-                fmt.preserve_ratio);
-            RgbToGrayscale(buffer_rgb_scaled.get(), fmt.buffer, fmt.width,
-                           fmt.height);
-          }
-        } break;
-        case CameraFormat::kRaw:
-          if (fmt.width != kWidth || fmt.height != kHeight) {
-            ret = false;
-            break;
-          }
-          std::memcpy(fmt.buffer, raw,
-                      kWidth * kHeight * CameraFormatBpp(CameraFormat::kRaw));
-          ret = true;
-          break;
-        default:
-          ret = false;
-      }
-    }
+    DBG_OUTPUT("F%d:%dx%d\n", index, kWidth, kHeight);
+    // std::memcpy(fmt.buffer, raw, kWidth * kHeight * 4);
+    Rgb8888ToRgb(raw, fmt.buffer, fmt.width, fmt.height);
+
+    ret = true;
+    break;
   }
 
   GetSingleton()->ReturnFrame(index);
@@ -566,34 +476,42 @@ bool CameraTask::Read(uint16_t reg, uint8_t* val) {
   transfer.data = val;
   transfer.dataSize = sizeof(*val);
   status_t status = LPI2C_RTOS_Transfer(i2c_handle_, &transfer);
+  DBG_OUTPUT("Rx|0x%04X=0x%02X|(%ld)\n", reg, *val, status);
   return status == kStatus_Success;
 }
 
 bool CameraTask::Write(uint16_t reg, uint8_t val) {
+  return Write(reg, &val, sizeof(val));
+}
+
+bool CameraTask::Write(uint16_t reg, const uint8_t *val, int size) {
   lpi2c_master_transfer_t transfer;
   transfer.flags = kLPI2C_TransferDefaultFlag;
   transfer.slaveAddress = kCameraAddress;
   transfer.direction = kLPI2C_Write;
   transfer.subaddress = static_cast<uint16_t>(reg);
   transfer.subaddressSize = sizeof(reg);
-  transfer.data = &val;
-  transfer.dataSize = sizeof(val);
+  transfer.data = (void *)val;
+  transfer.dataSize = size;
   status_t status = LPI2C_RTOS_Transfer(i2c_handle_, &transfer);
+  DBG_OUTPUT("Tx|0x%04X=0x%02X|(%ld)\n", reg, val[0], status);
   return status == kStatus_Success;
 }
 
-void CameraTask::Init(lpi2c_rtos_handle_t* i2c_handle) {
+void CameraTask::Init(lpi2c_rtos_handle_t* i2c_handle, lpi2c_rtos_handle_t* i2c_handle2) {
   QueueTask::Init();
   i2c_handle_ = i2c_handle;
+  i2c_handle2_ = i2c_handle2;
   enabled_ = false;
   GetMotionDetectionConfigDefault(md_config_);
   md_config_.enable = false;
-  GpioConfigureInterrupt(
-      Gpio::kCameraInt, GpioInterruptMode::kIntModeRising, [this]() {
-        camera::Request req;
-        req.type = camera::RequestType::kMotionDetectionInterrupt;
-        this->SendRequestAsync(req);
-      });
+
+  // GpioConfigureInterrupt(
+  //     Gpio::kCameraInt, GpioInterruptMode::kIntModeRising, [this]() {
+  //       camera::Request req;
+  //       req.type = camera::RequestType::kMotionDetectionInterrupt;
+  //       this->SendRequestAsync(req);
+  //     });
 }
 
 int CameraTask::GetFrame(uint8_t** buffer, bool block) {
@@ -638,6 +556,20 @@ bool CameraTask::SetPower(bool enable) {
   return resp.response.power.success;
 }
 
+void CameraTask::ChangePattern(void)
+{
+  CameraTestPattern val = CameraTestPattern::kNone;
+
+  if (test_pattern_ == CameraTestPattern::kNone)
+    val = CameraTestPattern::kColorBar;
+  else if (test_pattern_ == CameraTestPattern::kColorBar)
+    val = CameraTestPattern::kWalkingOnes;
+  else
+    val = CameraTestPattern::kNone;
+
+  SetTestPattern(val);
+}
+
 void CameraTask::SetTestPattern(CameraTestPattern pattern) {
   camera::Request req;
   req.type = camera::RequestType::kTestPattern;
@@ -645,7 +577,7 @@ void CameraTask::SetTestPattern(CameraTestPattern pattern) {
   SendRequest(req);
 }
 
-void CameraTask::Trigger() { GpioSet(Gpio::kCameraTrigger, true); }
+void CameraTask::Trigger() {}
 
 void CameraTask::DiscardFrames(int count) {
   camera::Request req;
@@ -655,20 +587,8 @@ void CameraTask::DiscardFrames(int count) {
 }
 
 void CameraTask::TaskInit() {
-  status_t status;
-  csi_config_.width = kCsiWidth;
-  csi_config_.height = kCsiHeight;
-  csi_config_.polarityFlags =
-      kCSI_HsyncActiveHigh | kCSI_VsyncActiveHigh | kCSI_DataLatchOnRisingEdge;
-  csi_config_.bytesPerPixel = 1;
-  csi_config_.linePitch_Bytes = kCsiWidth * 1;
-  csi_config_.workMode = kCSI_GatedClockMode;
-  csi_config_.dataBus = kCSI_DataBus8Bit;
-  csi_config_.useExtVsync = true;
-  status = CSI_Init(CSI, &csi_config_);
-  if (status != kStatus_Success) {
-    return;
-  }
+  printf("Camera %dx%d@%d %d bits per pixel\n",
+    DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT, DEMO_CAMERA_FRAME_RATE, DEMO_CAMERA_BUFFER_BPP * 8);
 
   camera::PowerRequest req;
   req.enable = false;
@@ -677,180 +597,219 @@ void CameraTask::TaskInit() {
 
 void CameraTask::SetMotionDetectionRegisters() {
   if (md_config_.enable) {
-    Write(CameraRegisters::kMdCtrl, 3);
-    Write(CameraRegisters::kMdThl, 1);
-    Write(CameraRegisters::kMdLroiXStartH, md_config_.x0 >> 8);
-    Write(CameraRegisters::kMdLroiXStartL, md_config_.x0 & 0xFF);
-    Write(CameraRegisters::kMdLroiYStartH, md_config_.y0 >> 8);
-    Write(CameraRegisters::kMdLroiYStartL, md_config_.y0 & 0xFF);
-    Write(CameraRegisters::kMdLroiXEndH, md_config_.x1 >> 8);
-    Write(CameraRegisters::kMdLroiXEndL, md_config_.x1 & 0xFF);
-    Write(CameraRegisters::kMdLroiYEndH, md_config_.y1 >> 8);
-    Write(CameraRegisters::kMdLroiYEndL, md_config_.y1 & 0xFF);
-    Write(CameraRegisters::kI2cClear, 1);
   } else {
-    Write(CameraRegisters::kMdCtrl, 0);
   }
 }
 
-void CameraTask::SetDefaultRegisters() {
-  // Taken from Tensorflow's configuration in the person detection sample
-  /* Analog settings */
-  Write(CameraRegisters::kBlcTgt, 0x08);
-  Write(CameraRegisters::kBlc2Tgt, 0x08);
-  /* These registers are RESERVED in the datasheet,
-   * but without them the picture is bad. */
-  Write(0x3044, 0x0A);
-  Write(0x3045, 0x00);
-  Write(0x3047, 0x0A);
-  Write(0x3050, 0xC0);
-  Write(0x3051, 0x42);
-  Write(0x3052, 0x50);
-  Write(0x3053, 0x00);
-  Write(0x3054, 0x03);
-  Write(0x3055, 0xF7);
-  Write(0x3056, 0xF8);
-  Write(0x3057, 0x29);
-  Write(0x3058, 0x1F);
-  Write(CameraRegisters::kBitControl, 0x1E);
-  /* Digital settings */
-  Write(CameraRegisters::kBlcCfg, 0x43);
-  Write(CameraRegisters::kBlcDither, 0x40);
-  Write(CameraRegisters::kBlcDarkpixel, 0x32);
-  Write(CameraRegisters::kDgainControl, 0x7F);
-  Write(CameraRegisters::kBliEn, 0x01);
-  Write(CameraRegisters::kDpcCtrl, 0x00);
-  Write(CameraRegisters::kClusterThrHot, 0xA0);
-  Write(CameraRegisters::kClusterThrCold, 0x60);
-  Write(CameraRegisters::kSingleThrHot, 0x90);
-  Write(CameraRegisters::kSingleThrCold, 0x40);
-  /* AE settings */
-  Write(CameraRegisters::kStatisticCtrl, 0x07);
-  Write(CameraRegisters::kAeCtrl, 0x01);
-  Write(CameraRegisters::kAeTargetMean, 0x5F);
-  Write(CameraRegisters::kAeMinMean, 0x0A);
-  Write(CameraRegisters::kConvergeInTh, 0x03);
-  Write(CameraRegisters::kConvergeOutTh, 0x05);
-  Write(CameraRegisters::kMaxIntgH, 0x02);
-  Write(CameraRegisters::kMaxIntgL, 0x14);
-  Write(CameraRegisters::kMinIntg, 0x02);
-  Write(CameraRegisters::kMaxAgainFull, 0x03);
-  Write(CameraRegisters::kMaxAgainBin2, 0x03);
-  Write(CameraRegisters::kMinAgain, 0x00);
-  Write(CameraRegisters::kMaxDgain, 0x80);
-  Write(CameraRegisters::kMinDgain, 0x40);
-  Write(CameraRegisters::kDampingFactor, 0x20);
-  /* 60Hz flicker */
-  Write(CameraRegisters::kFsCtrl, 0x03);
-  Write(CameraRegisters::kFs60HzH, 0x00);
-  Write(CameraRegisters::kFs60HzL, 0x85);
-  Write(CameraRegisters::kFs50HzH, 0x00);
-  Write(CameraRegisters::kFs50HzL, 0xA0);
+bool CameraTask::VideoConvert(uint32_t in)
+{
+      pxp_ps_buffer_config_t psBufferConfig = {
+#if (!(defined(FSL_FEATURE_PXP_HAS_NO_EXTEND_PIXEL_FORMAT) && FSL_FEATURE_PXP_HAS_NO_EXTEND_PIXEL_FORMAT)) || \
+    (!(defined(FSL_FEATURE_PXP_V3) && FSL_FEATURE_PXP_V3))
+        .pixelFormat = kPXP_PsPixelFormatRGB888, //kPXP_PsPixelFormatARGB8888,
+#else
+        .pixelFormat = kPXP_PsPixelFormatRGB888, /* Note: This is 32-bit per pixel */
+#endif
+        .swapByte    = false,
+        .bufferAddrU = 0U,
+        .bufferAddrV = 0U,
+        .pitchBytes  = DEMO_CAMERA_WIDTH * DEMO_CAMERA_BUFFER_BPP,
+    };
 
-  SetMotionDetectionRegisters();
+    /* Output config. */
+    pxp_output_buffer_config_t outputBufferConfig = {
+        .pixelFormat    = kPXP_OutputPixelFormatRGB888P,
+        .interlacedMode = kPXP_OutputProgressive,
+        .buffer1Addr    = 0U,
+        .pitchBytes     = DEMO_BUFFER_WIDTH * 3,
+#if DEMO_ROTATE_FRAME
+        .width  = DEMO_BUFFER_HEIGHT,
+        .height = DEMO_BUFFER_WIDTH,
+#else
+        .width       = DEMO_BUFFER_WIDTH,
+        .height      = DEMO_BUFFER_HEIGHT,
+#endif
+    };
+
+  /* Convert the camera input picture to RGB format. */
+  psBufferConfig.bufferAddr = in;
+  PXP_SetProcessSurfaceBufferConfig(DEMO_PXP, &psBufferConfig);
+
+  outputBufferConfig.buffer0Addr = (uint32_t)pxp_buffer;
+  PXP_SetOutputBufferConfig(DEMO_PXP, &outputBufferConfig);
+
+  printf("pxp starting ...\r\n");
+
+  PXP_Start(DEMO_PXP);
+
+  printf("pxp waiting to complete ...\r\n");
+
+  /* Wait for PXP process complete. */
+  while (!(kPXP_CompleteFlag & PXP_GetStatusFlags(DEMO_PXP)));
+
+  printf("pxp done\r\n");
+
+  PXP_ClearStatusFlags(DEMO_PXP, kPXP_CompleteFlag);
 }
 
 camera::EnableResponse CameraTask::HandleEnableRequest(const CameraMode& mode) {
   camera::EnableResponse resp;
   status_t status;
+  camera_config_t cameraConfig;
 
-  // Gated clock mode
-  uint8_t osc_clk_div;
-  Read(CameraRegisters::kOscClkDiv, &osc_clk_div);
-  osc_clk_div |= 1 << 5;
-  Write(CameraRegisters::kOscClkDiv, osc_clk_div);
+  BOARD_InitPxp();
+  BOARD_InitCamera();
 
-  SetDefaultRegisters();
-
-  // Shifting
-  Write(CameraRegisters::kVsyncHsyncPixelShiftEn, 0x0);
-
-  status = CSI_TransferCreateHandle(CSI, &csi_handle_, nullptr, 0);
-
-  int framebuffer_count = kFramebufferCount;
-  if (mode == CameraMode::kTrigger) {
-    framebuffer_count = 2;
-  }
-  for (int i = 0; i < framebuffer_count; i++) {
-    status = CSI_TransferSubmitEmptyBuffer(
-        CSI, &csi_handle_, reinterpret_cast<uint32_t>(framebuffers[i]));
+  for(int n=0; n<10; n++)
+  {
+    uint8_t val;
+    Read(0x3008, &val);
+    vTaskDelay(pdMS_TO_TICKS(10));
   }
 
-  // Streaming
-  status = CSI_TransferStart(CSI, &csi_handle_);
-  SetMode(mode);
+  BOARD_PxpConfig();
+
+  coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kUserLed, 1);
+
+  status = CAMERA_RECEIVER_Start(&cameraReceiver);
+  printf("CAMERA_RECEIVER_Start = %ld\n", status);
+
   resp.success = (status == kStatus_Success);
+
   return resp;
+}
+
+bool CameraTask::Detect(void)
+{
+  uint8_t model_id_h = 0xff, model_id_l = 0xff;
+
+  for (int i = 0; i < 10; ++i) {
+      Read(0x300A, &model_id_h);
+      Read(0x300B, &model_id_l);
+      if (model_id_h == kModelIdHExpected && model_id_l == kModelIdLExpected) {
+        return true;
+      }
+  }
+
+  if (model_id_h != kModelIdHExpected || model_id_l != kModelIdLExpected) {
+    printf("Camera model id not as expected!!!!!: 0x%02x%02x\r\n", model_id_h,
+            model_id_l);
+  }
+
+  return false;
 }
 
 void CameraTask::HandleDisableRequest() {
   enabled_ = false;
-  Write(CameraRegisters::kModeSelect, 0);
-  CSI_TransferStop(CSI, &csi_handle_);
+
+  status_t status = CAMERA_RECEIVER_Stop(&cameraReceiver);
+  printf("CAMERA_RECEIVER_Stop = %ld\n", status);
 }
 
 camera::PowerResponse CameraTask::HandlePowerRequest(
     const camera::PowerRequest& power) {
   camera::PowerResponse resp;
   resp.success = true;
+
   PmicTask::GetSingleton()->SetRailState(PmicRail::kCam2V8, power.enable);
   PmicTask::GetSingleton()->SetRailState(PmicRail::kCam1V8, power.enable);
   vTaskDelay(pdMS_TO_TICKS(10));
 
   if (power.enable) {
-    uint8_t model_id_h = 0xff, model_id_l = 0xff;
-    for (int i = 0; i < 10; ++i) {
-      Read(CameraRegisters::kModelIdH, &model_id_h);
-      Read(CameraRegisters::kModelIdL, &model_id_l);
-      Write(CameraRegisters::kSwReset, 0x00);
-      if (model_id_h == kModelIdHExpected && model_id_l == kModelIdLExpected) {
-        break;
-      }
-    }
 
-    if (model_id_h != kModelIdHExpected || model_id_l != kModelIdLExpected) {
-      printf("Camera model id not as expected: 0x%02x%02x\r\n", model_id_h,
-             model_id_l);
-      resp.success = false;
+    coralmicro::GpioSet((coralmicro::Gpio) Gpio::kCamPwrDn, 0);
+    vTaskDelay(pdMS_TO_TICKS(2));
+
+    coralmicro::GpioSet((coralmicro::Gpio) Gpio::kCamReset, 1);
+    vTaskDelay(pdMS_TO_TICKS(40));
+
+    // Check on first I2C bus, then switch on 2nd if fail
+    resp.success = CameraTask::Detect();
+    if (!resp.success && i2c_handle2_)
+    {
+      i2c_handle_ = i2c_handle2_;
+      resp.success = CameraTask::Detect();
     }
+    else
+      resp.success = true;
   }
+
   return resp;
 }
 
 camera::FrameResponse CameraTask::HandleFrameRequest(
     const camera::FrameRequest& frame) {
-  camera::FrameResponse resp;
-  resp.index = -1;
+  camera::FrameResponse resp = {
+    .index = -1
+  };
+  status_t status;
   uint32_t buffer;
+
+  coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kStatusLed, 0);
+
   if (frame.index == -1) {  // GET
-    status_t status = CSI_TransferGetFullBuffer(CSI, &csi_handle_, &buffer);
+    // get new frame buffer
+    int n = 40;
+    bool state = true;
+
+    DBG_OUTPUT ("CAMERA_RECEIVER_GetFullBuffer:waiting...\n");
+
+    while(n--)
+    {
+      status = CAMERA_RECEIVER_GetFullBuffer(&cameraReceiver, &buffer);
+      if (status == kStatus_Success)
+      {
+        break;
+      }
+
+      vTaskDelay(100);
+
+      coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kStatusLed, state);
+      state = !state;
+    }
+
+    DBG_OUTPUT("CAMERA_RECEIVER_GetFullBuffer = %ld\n", status);
+
     if (status == kStatus_Success) {
-      DCACHE_InvalidateByRange(buffer, kHeight * kWidth);
+      // DBG_OUTPUT ("CAMERA_RECEIVER_GetFullBuffer:status = OK, invalidate %d bytes\n", sizeof(framebuffers[0]));
+      // DCACHE_InvalidateByRange(buffer, sizeof(framebuffers[0]));
+
+      coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kStatusLed, 0);
+
       resp.index = FramebufferPtrToIndex(reinterpret_cast<uint8_t*>(buffer));
+    }
+    else {
+      printf ("CAMERA_RECEIVER_GetFullBuffer:status = %ld\n", status);
+
+      coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kStatusLed, 1);
     }
   } else {  // RETURN
     buffer = reinterpret_cast<uint32_t>(IndexToFramebufferPtr(frame.index));
+
     if (buffer) {
-      CSI_TransferSubmitEmptyBuffer(CSI, &csi_handle_, buffer);
+      status = CAMERA_RECEIVER_SubmitEmptyBuffer(&cameraReceiver, (uint32_t)buffer);
+      DBG_OUTPUT ("CAMERA_RECEIVER_SubmitEmptyBuffer:status = %ld\n", status);
     }
   }
+
+  coralmicro::GpioSet((coralmicro::Gpio) coralmicro::Gpio::kStatusLed, 0);
+
+  // CamDumpRegistersOnly();
+
+  uint32_t reg1 = 0x40810108;
+  uint32_t reg2 = 0x4081010c;
+  if (*(uint32_t*)reg1)
+    printf ("%08lX=%08lX\n",reg1, *(uint32_t*)reg1);
+
+  if (*(uint32_t*)reg2)
+    printf ("%08lX=%08lX\n",reg2, *(uint32_t*)reg2);
+
   return resp;
 }
 
 void CameraTask::HandleTestPatternRequest(
     const camera::TestPatternRequest& test_pattern) {
-  if (test_pattern.pattern == CameraTestPattern::kNone) {
-    SetDefaultRegisters();
-  } else {
-    Write(CameraRegisters::kAeCtrl, 0x00);
-    Write(CameraRegisters::kBlcCfg, 0x00);
-    Write(CameraRegisters::kDpcCtrl, 0x00);
-    Write(CameraRegisters::kAnalogGain, 0x00);
-    Write(CameraRegisters::kDigitalGainH, 0x01);
-    Write(CameraRegisters::kDigitalGainL, 0x00);
-  }
-  Write(CameraRegisters::kTestPatternMode,
-        static_cast<uint8_t>(test_pattern.pattern));
+  Write(0x503D, (uint8_t)test_pattern.pattern);
   test_pattern_ = test_pattern.pattern;
 }
 
@@ -895,14 +854,12 @@ void CameraTask::HandleMotionDetectionConfig(
 }
 
 void CameraTask::HandleMotionDetectionInterrupt() {
-  Write(CameraRegisters::kI2cClear, 1);
   if (md_config_.cb) {
-    md_config_.cb(md_config_.cb_param);
+    // md_config_.cb(md_config_.cb_param);
   }
 }
 
 void CameraTask::SetMode(const CameraMode& mode) {
-  Write(CameraRegisters::kModeSelect, static_cast<uint8_t>(mode));
   mode_ = mode;
 }
 

--- a/libs/camera/camera.h
+++ b/libs/camera/camera.h
@@ -26,6 +26,8 @@
 #include "third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/fsl_csi.h"
 #include "third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/fsl_lpi2c_freertos.h"
 
+#include "camera_support.h"
+
 namespace coralmicro {
 
 // The camera operating mode for `CameraTask::Enable()`.
@@ -43,8 +45,8 @@ enum class CameraMode : uint8_t {
 // Test patterns to use with `CameraTask::SetTestPattern()`
 enum class CameraTestPattern : uint8_t {
   kNone = 0x00,
-  kColorBar = 0x01,
-  kWalkingOnes = 0x11,
+  kColorBar = 0x80,
+  kWalkingOnes = 0x84,
 };
 
 // The function type required by `CameraMotionDetectionConfig`.
@@ -237,7 +239,7 @@ class CameraTask
   // ```
   //
   // @param i2c_handle The camera I2C handle: `I2C5Handle()`.
-  void Init(lpi2c_rtos_handle_t* i2c_handle);
+  void Init(lpi2c_rtos_handle_t* i2c_handle, lpi2c_rtos_handle_t* i2c_handle_2nd = nullptr);
 
   // Gets the `CameraTask` singleton.
   //
@@ -252,6 +254,7 @@ class CameraTask
   // @param mode The operating mode (either `kStreaming` or `kTrigger`).
   // @return True if camera is enabled, false otherwise.
   bool Enable(CameraMode mode);
+  void ChangePattern(void);
 
   // Sets the camera into a low-power state, using appoximately 200 μW
   // (compared to approximately 4 mW when streaming). The camera configuration
@@ -311,12 +314,17 @@ class CameraTask
   void SetMotionDetectionConfig(const CameraMotionDetectionConfig& config);
 
   // Native image pixel width.
-  static constexpr size_t kWidth = 324;
+  static constexpr size_t kWidth = DEMO_CAMERA_WIDTH;
 
   // Native image pixel height.
-  static constexpr size_t kHeight = 324;
+  static constexpr size_t kHeight = DEMO_CAMERA_HEIGHT;
+
+  bool Read(uint16_t reg, uint8_t* val);
+  bool Write(uint16_t reg, uint8_t val);
+  bool Write(uint16_t reg, const uint8_t *val, int size);
 
  private:
+  bool VideoConvert(uint32_t in);
   int GetFrame(uint8_t** buffer, bool block);
   void ReturnFrame(int index);
   void TaskInit() override;
@@ -330,12 +338,12 @@ class CameraTask
   void HandleMotionDetectionInterrupt();
   void HandleMotionDetectionConfig(const CameraMotionDetectionConfig& config);
   void SetMode(const CameraMode& mode);
-  bool Read(uint16_t reg, uint8_t* val);
-  bool Write(uint16_t reg, uint8_t val);
   void SetDefaultRegisters();
   void SetMotionDetectionRegisters();
+  bool Detect(void);
 
   lpi2c_rtos_handle_t* i2c_handle_;
+  lpi2c_rtos_handle_t* i2c_handle2_;
   csi_handle_t csi_handle_;
   csi_config_t csi_config_;
   CameraMode mode_;

--- a/libs/camera/camera_support.c
+++ b/libs/camera/camera_support.c
@@ -1,0 +1,447 @@
+/*
+ * Copyright  2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "camera_support.h"
+#include "fsl_gpio.h"
+#include "fsl_csi.h"
+#include "fsl_csi_camera_adapter.h"
+#include "fsl_ov5640.h"
+#include "fsl_mipi_csi2rx.h"
+#include "board.h"
+#include "fsl_debug_console.h"
+#include "fsl_pxp.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define DEMO_CSI_CLK_FREQ          (CLOCK_GetRootClockFreq(kCLOCK_Root_Bus))
+#define DEMO_MIPI_CSI2_UI_CLK_FREQ (CLOCK_GetRootClockFreq(kCLOCK_Root_Csi2_Ui))
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+static status_t BOARD_VerifyCameraClockSource(void);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* Camera connect to CSI. */
+static csi_resource_t csiResource = {
+    .csiBase = CSI,
+    .dataBus = kCSI_DataBus24Bit,
+};
+
+static csi_private_data_t csiPrivateData;
+
+camera_receiver_handle_t cameraReceiver = {
+    .resource    = &csiResource,
+    .ops         = &csi_ops,
+    .privateData = &csiPrivateData,
+};
+
+static ov5640_resource_t ov5640Resource = {
+    .i2cSendFunc      = BOARD_Camera_I2C_SendSCCB,
+    .i2cReceiveFunc   = BOARD_Camera_I2C_ReceiveSCCB,
+    .pullResetPin     = BOARD_PullCameraResetPin,
+    .pullPowerDownPin = BOARD_PullCameraPowerDownPin,
+};
+
+camera_device_handle_t cameraDevice = {
+    .resource = &ov5640Resource,
+    .ops      = &ov5640_ops,
+};
+
+#ifdef CPU_MIMXRT1176CVM8A_cm4
+__attribute__((section(".sdram_bss,\"aw\",%nobits @")))
+__attribute__((aligned(DEMO_CAMERA_BUFFER_ALIGN)))
+uint8_t
+    framebuffers[DEMO_CAMERA_BUFFER_COUNT][DEMO_CAMERA_HEIGHT][(DEMO_CAMERA_WIDTH + LINE_PADDING) * DEMO_CAMERA_BUFFER_BPP];
+#else
+__attribute__((section("NonCacheableCamera,\"aw\",%nobits @")))
+__attribute__((aligned(DEMO_CAMERA_BUFFER_ALIGN)))
+uint8_t
+    framebuffers[DEMO_CAMERA_BUFFER_COUNT]
+        [(DEMO_CAMERA_HEIGHT) * (DEMO_CAMERA_WIDTH + LINE_PADDING) * DEMO_CAMERA_BUFFER_BPP];
+#endif
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+extern void CSI_DriverIRQHandler(void);
+
+void CSI_IRQHandler(void)
+{
+    CSI_DriverIRQHandler();
+    __DSB();
+}
+
+void BOARD_EarlyInitCamera(void)
+{
+    /* If the camera I2C bus should be released by sending I2C sequence,
+     * add the code here.
+     */
+}
+
+void BOARD_InitCameraResource(void)
+{
+    // BOARD_Camera_I2C_Init();
+
+    /* CSI MCLK is connect to dedicated 24M OSC, so don't need to configure it. */
+}
+
+void BOARD_InitMipiCsi(void)
+{
+    csi2rx_config_t csi2rxConfig = {0};
+
+    /* This clock should be equal or faster than the receive byte clock,
+     * D0_HS_BYTE_CLKD, from the RX DPHY. For this board, there are two
+     * data lanes, the MIPI CSI pixel format is 16-bit per pixel, the
+     * max resolution supported is 720*1280@30Hz, so the MIPI CSI2 clock
+     * should be faster than 720*1280*30 = 27.6MHz, choose 60MHz here.
+     */
+    const clock_root_config_t csi2ClockConfig = {
+        .clockOff = false,
+        .mux      = 5,
+        .div      = 8,
+    };
+
+    /* ESC clock should be in the range of 60~80 MHz */
+    const clock_root_config_t csi2EscClockConfig = {
+        .clockOff = false,
+        .mux      = 5,
+        .div      = 8,
+    };
+
+    /* UI clock should be equal or faster than the input pixel clock.
+     * The camera max resolution supported is 720*1280@30Hz, so this clock
+     * should be faster than 720*1280*30 = 27.6MHz, choose 60MHz here.
+     */
+    const clock_root_config_t csi2UiClockConfig = {
+        .clockOff = false,
+        .mux      = 5,
+        .div      = 8,
+    };
+
+    if (kStatus_Success != BOARD_VerifyCameraClockSource())
+    {
+        PRINTF("MIPI CSI clock source not valid\r\n");
+        while (1)
+        {
+        }
+    }
+
+    /* MIPI CSI2 connect to CSI. */
+    CLOCK_EnableClock(kCLOCK_Video_Mux);
+    VIDEO_MUX->VID_MUX_CTRL.SET = (VIDEO_MUX_VID_MUX_CTRL_CSI_SEL_MASK);
+
+    CLOCK_SetRootClock(kCLOCK_Root_Csi2, &csi2ClockConfig);
+    CLOCK_SetRootClock(kCLOCK_Root_Csi2_Esc, &csi2EscClockConfig);
+    CLOCK_SetRootClock(kCLOCK_Root_Csi2_Ui, &csi2UiClockConfig);
+
+    /* The CSI clock should be faster than MIPI CSI2 clk_ui. The CSI clock
+     * is bus clock.
+     */
+    if (DEMO_CSI_CLK_FREQ < DEMO_MIPI_CSI2_UI_CLK_FREQ)
+    {
+        PRINTF("CSI clock should be faster than MIPI CSI2 ui clock.\r\n");
+        while (1)
+        {
+        }
+    }
+
+    /* MIPI DPHY power on and isolation off. */
+    PGMC_BPC4->BPC_POWER_CTRL |= (PGMC_BPC_BPC_POWER_CTRL_PSW_ON_SOFT_MASK | PGMC_BPC_BPC_POWER_CTRL_ISO_OFF_SOFT_MASK);
+
+    /*
+     * Initialize the MIPI CSI2
+     *
+     * From D-PHY specification, the T-HSSETTLE should in the range of 85ns+6*UI to 145ns+10*UI
+     * UI is Unit Interval, equal to the duration of any HS state on the Clock Lane
+     *
+     * T-HSSETTLE = csi2rxConfig.tHsSettle_EscClk * (Tperiod of RxClkInEsc)
+     *
+     * csi2rxConfig.tHsSettle_EscClk setting for camera:
+     *
+     *    Resolution  |  frame rate  |  T_HS_SETTLE
+     *  =============================================
+     *     720P       |     30       |     0x12
+     *  ---------------------------------------------
+     *     720P       |     15       |     0x17
+     *  ---------------------------------------------
+     *      VGA       |     30       |     0x1F
+     *  ---------------------------------------------
+     *      VGA       |     15       |     0x24
+     *  ---------------------------------------------
+     *     QVGA       |     30       |     0x1F
+     *  ---------------------------------------------
+     *     QVGA       |     15       |     0x24
+     *  ---------------------------------------------
+     */
+    static const uint32_t csi2rxHsSettle[][3] = {
+        {
+            kVIDEO_Resolution1080P,
+            15,
+            0x12,
+        },
+        {
+            kVIDEO_Resolution720P,
+            30,
+            0x12,
+        },
+        {
+            kVIDEO_Resolution720P,
+            15,
+            0x17,
+        },
+        {
+            kVIDEO_ResolutionVGA,
+            30,
+            0x1F,
+        },
+        {
+            kVIDEO_ResolutionVGA,
+            15,
+            0x24,
+        },
+        {
+            kVIDEO_ResolutionQVGA,
+            30,
+            0x1F,
+        },
+        {
+            kVIDEO_ResolutionQVGA,
+            15,
+            0x24,
+        },
+    };
+
+    csi2rxConfig.laneNum          = DEMO_CAMERA_MIPI_CSI_LANE;
+    csi2rxConfig.tHsSettle_EscClk = 0x12;
+
+    for (uint8_t i = 0; i < ARRAY_SIZE(csi2rxHsSettle); i++)
+    {
+        if ((FSL_VIDEO_RESOLUTION(DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT) == csi2rxHsSettle[i][0]) &&
+            (csi2rxHsSettle[i][1] == DEMO_CAMERA_FRAME_RATE))
+        {
+            csi2rxConfig.tHsSettle_EscClk = csi2rxHsSettle[i][2];
+            break;
+        }
+    }
+
+    CSI2RX_Init(MIPI_CSI2RX, &csi2rxConfig);
+}
+
+static status_t BOARD_VerifyCameraClockSource(void)
+{
+    status_t status;
+    uint32_t srcClkFreq;
+    /*
+     * The MIPI CSI clk_ui, clk_esc, and core_clk are all from
+     * System PLL3 (PLL_480M). Verify the clock source to ensure
+     * it is ready to use.
+     */
+    srcClkFreq = CLOCK_GetPllFreq(kCLOCK_PllSys3);
+
+    if (480 != (srcClkFreq / 1000000))
+    {
+        status = kStatus_Fail;
+    }
+    else
+    {
+        status = kStatus_Success;
+    }
+
+    return status;
+}
+
+void BOARD_InitPxp(void)
+{
+    /*
+     * Configure the PXP for rotate and scale.
+     */
+    PXP_Init(DEMO_PXP);
+
+    PXP_SetProcessSurfaceBackGroundColor(DEMO_PXP, 0U);
+
+#if DEMO_ROTATE_FRAME
+    PXP_SetProcessSurfacePosition(DEMO_PXP, 0U, 0U, DEMO_BUFFER_HEIGHT - 1U, DEMO_BUFFER_WIDTH - 1U);
+#else
+    PXP_SetProcessSurfacePosition(DEMO_PXP, 0U, 0U, DEMO_BUFFER_WIDTH - 1U, DEMO_BUFFER_HEIGHT - 1U);
+#endif
+
+    /* Disable AS. */
+    PXP_SetAlphaSurfacePosition(DEMO_PXP, 0xFFFFU, 0xFFFFU, 0U, 0U);
+
+    PXP_EnableCsc1(DEMO_PXP, false);
+}
+
+void BOARD_InitCamera(void)
+{
+    status_t status;
+    camera_config_t cameraConfig;
+
+    memset(&cameraConfig, 0, sizeof(cameraConfig));
+
+    BOARD_InitCameraResource();
+
+    /* CSI input data bus is 24-bit, and save as XRGB8888.. */
+    cameraConfig.pixelFormat                = kVIDEO_PixelFormatXRGB8888;
+    cameraConfig.bytesPerPixel              = DEMO_CAMERA_BUFFER_BPP;
+    cameraConfig.resolution                 = FSL_VIDEO_RESOLUTION(DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT);
+    cameraConfig.frameBufferLinePitch_Bytes = DEMO_CAMERA_WIDTH * DEMO_CAMERA_BUFFER_BPP;
+    cameraConfig.interface                  = kCAMERA_InterfaceGatedClock;
+    cameraConfig.controlFlags               = DEMO_CAMERA_CONTROL_FLAGS;
+    cameraConfig.framePerSec                = DEMO_CAMERA_FRAME_RATE;
+
+    status = CAMERA_RECEIVER_Init(&cameraReceiver, &cameraConfig, NULL, NULL);
+    printf("CAMERA_RECEIVER_Init = %ld\n", status);
+
+    BOARD_InitMipiCsi();
+
+    cameraConfig.pixelFormat   = kVIDEO_PixelFormatRGB565;
+    cameraConfig.bytesPerPixel = 2;
+    cameraConfig.resolution    = FSL_VIDEO_RESOLUTION(DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT);
+    cameraConfig.interface     = kCAMERA_InterfaceMIPI;
+    cameraConfig.controlFlags  = DEMO_CAMERA_CONTROL_FLAGS;
+    cameraConfig.framePerSec   = DEMO_CAMERA_FRAME_RATE;
+    cameraConfig.csiLanes      = DEMO_CAMERA_MIPI_CSI_LANE;
+
+    status = CAMERA_DEVICE_Init(&cameraDevice, &cameraConfig);
+    printf("CAMERA_DEVICE_Init = %ld\n", status);
+
+    status = CAMERA_DEVICE_Start(&cameraDevice);
+    printf("CAMERA_DEVICE_Start = %ld\n", status);
+
+    /* Submit the empty frame buffers to buffer queue. */
+    for (uint32_t i = 0; i < DEMO_CAMERA_BUFFER_COUNT; i++)
+    {
+        status = CAMERA_RECEIVER_SubmitEmptyBuffer(&cameraReceiver, (uint32_t)(framebuffers[i]));
+        printf("CAMERA_RECEIVER_SubmitEmptyBuffer (%08lX) = %ld\n", (uint32_t)framebuffers[i], status);
+    }
+}
+
+void BOARD_PxpConfig(void)
+{
+    PXP_SetProcessSurfaceBackGroundColor(DEMO_PXP, 0);
+    /* Rotate and scale the camera input to fit display output. */
+#if DEMO_ROTATE_FRAME
+    /* The PS rotate and scale could not work at the same time, so rotate the output. */
+    PXP_SetRotateConfig(DEMO_PXP, kPXP_RotateOutputBuffer, kPXP_Rotate90, kPXP_FlipDisable);
+    PXP_SetProcessSurfaceScaler(DEMO_PXP, DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT, DEMO_BUFFER_HEIGHT, DEMO_BUFFER_WIDTH);
+#else
+    PXP_SetProcessSurfaceScaler(DEMO_PXP, DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT, DEMO_BUFFER_WIDTH, DEMO_BUFFER_HEIGHT);
+#endif
+}
+
+uint8_t* IndexToFramebufferPtr(int index) {
+  if (index < 0 || index >= DEMO_CAMERA_BUFFER_COUNT) {
+    return NULL;
+  }
+  return (uint8_t*)(framebuffers[index]);
+}
+
+int FramebufferPtrToIndex(const uint8_t* framebuffer_ptr) {
+  for (int i = 0; i < DEMO_CAMERA_BUFFER_COUNT; ++i) {
+    if ((uint8_t*)(framebuffers[i]) == framebuffer_ptr) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+typedef struct {
+	uint16_t start;
+	uint16_t end;
+} reg_range_t;
+
+void CamDumpRegistersOnly(void)
+{
+    uint8_t val;
+    reg_range_t ov5640_regs[] = {
+            {0x3000, 0x3052},
+            {0x3100, 0x3108},
+            {0x3200, 0x3211},
+            {0x3400, 0x3406},
+            {0x3500, 0x350D},
+            {0x3600, 0x3606},
+            {0x3800, 0x3821},
+            {0x3A00, 0x3A25},
+            {0x3B00, 0x3B0C},
+            {0x3c00, 0x3c1e},
+            {0x3d00, 0x3d21},
+            {0x3f00, 0x3f02},
+            {0x4000, 0x4033},
+            {0x4201, 0x4202},
+            {0x4300, 0x430d},
+            {0x4400, 0x4431},
+            {0x4600, 0x460d},
+            {0x4709, 0x4745},
+            {0x4800, 0x4837},
+            {0x4900, 0x4902},
+            {0x5000, 0x5063},
+            {0x5180, 0x51d0},
+            {0x5300, 0x530f},
+            {0x5380, 0x538d},
+            {0x5480, 0x5490},
+            {0x5580, 0x558c},
+            {0x5600, 0x5606},
+            {0x5680, 0x56a2},
+            {0x5800, 0x5849},
+            {0x6000, 0x603f}
+    };
+
+    printf("Camera %dx%d@%d %d bits per pixel\n",
+    DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT, DEMO_CAMERA_FRAME_RATE, DEMO_CAMERA_BUFFER_BPP * 8);
+
+    for (int n=0; n<sizeof(ov5640_regs)/sizeof(ov5640_regs[0]); n++)
+    {
+        for (uint16_t reg = ov5640_regs[n].start; reg <= ov5640_regs[n].end; reg++)
+        {
+            status_t ret = BOARD_Camera_I2C_ReceiveSCCB(0x3c, reg, 2, &val, sizeof(val));
+            printf ("0x%04X = 0x%02X (err: %ld)\n", reg, val, ret);
+        }
+    }
+}
+
+void CamDumpRegisters(void)
+{
+    uint16_t ov5640_regs[] = {
+        0x3034, 0x3035, 0x3036, 0x3037, 0x4837, 0x3108
+    };
+    uint8_t val;
+
+    printf("Camera %dx%d@%d %d bits per pixel\n",
+    DEMO_CAMERA_WIDTH, DEMO_CAMERA_HEIGHT, DEMO_CAMERA_FRAME_RATE, DEMO_CAMERA_BUFFER_BPP * 8);
+
+    for (int n=0; n<sizeof(ov5640_regs)/sizeof(ov5640_regs[0]); n++)
+    {
+        status_t ret = BOARD_Camera_I2C_ReceiveSCCB(0x3c, ov5640_regs[n], 2, &val, sizeof(val));
+        printf ("0x%04X = 0x%02X (err: %ld)\n", ov5640_regs[n], val, ret);
+    }
+
+    uint32_t base1 = 0x40CC0000;
+    uint16_t offset1[] = {0x2480, 0x2580, 0x2500};
+
+    for (int n=0; n<sizeof(offset1)/sizeof(offset1[0]); n++)
+    {
+        printf ("0x%08lX=%08lX\n", base1 + offset1[n], *(uint32_t*)(base1 + offset1[n]));
+    }
+
+    uint32_t base2 = 0x400E4000;
+    uint16_t offset2[] = {0x00EC};
+
+    for (int n=0; n<sizeof(offset2)/sizeof(offset2[0]); n++)
+    {
+        printf ("0x%08lX=%08lX\n", base2 + offset2[n], *(uint32_t*)(base2 + offset2[n]));
+    }
+
+    for (int n=0; n<14; n++)
+    {
+        printf ("40810%03X=%08lX\n",0x100 + (n * 4),
+            *(uint32_t*)(0x40810000 + 0x100 + (n * 4)));
+    }
+}

--- a/libs/camera/camera_support.h
+++ b/libs/camera/camera_support.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CAMERA_SUPPORT_H_
+#define _CAMERA_SUPPORT_H_
+
+#include "fsl_camera.h"
+#include "fsl_camera_receiver.h"
+#include "fsl_camera_device.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+#ifdef CPU_MIMXRT1176CVM8A_cm4
+// Not really used
+#define DEMO_CAMERA_HEIGHT        240
+#define DEMO_CAMERA_WIDTH         320
+#define DEMO_CAMERA_BUFFER_COUNT  2
+#else
+
+// Choose here your resolution and number of FBs
+#define DEMO_CAMERA_HEIGHT  720
+#define DEMO_CAMERA_WIDTH   1280
+#define DEMO_CAMERA_BUFFER_COUNT 3
+
+// #define DEMO_CAMERA_HEIGHT  240
+// #define DEMO_CAMERA_WIDTH   320
+// #define DEMO_CAMERA_BUFFER_COUNT 3
+
+// #define DEMO_CAMERA_HEIGHT  1080
+// #define DEMO_CAMERA_WIDTH   1920
+// #define DEMO_CAMERA_BUFFER_COUNT 2
+
+#endif
+#define DEMO_CAMERA_FRAME_RATE    15
+#define DEMO_CAMERA_CONTROL_FLAGS (kCAMERA_HrefActiveHigh | kCAMERA_DataLatchOnRisingEdge)
+#define DEMO_CAMERA_BUFFER_ALIGN  64
+#define DEMO_CAMERA_MIPI_CSI_LANE 2
+#define DEMO_CAMERA_BUFFER_BPP 4
+
+#define LINE_PADDING              0
+
+#define DEMO_BUFFER_WIDTH  DEMO_CAMERA_WIDTH
+#define DEMO_BUFFER_HEIGHT DEMO_CAMERA_HEIGHT
+#define DEMO_PXP PXP
+
+extern camera_device_handle_t cameraDevice;
+extern camera_receiver_handle_t cameraReceiver;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/* This function should be called before camera pins initialization */
+void BOARD_EarlyInitCamera(void);
+
+void BOARD_InitCameraResource(void);
+
+void BOARD_InitMipiCsi(void);
+
+status_t BOARD_Camera_I2C_SendSCCB(
+    uint8_t deviceAddress, uint32_t subAddress, uint8_t subAddressSize, const uint8_t *txBuff, uint8_t txBuffSize);
+
+status_t BOARD_Camera_I2C_ReceiveSCCB(
+    uint8_t deviceAddress, uint32_t subAddress, uint8_t subAddressSize, uint8_t *rxBuff, uint8_t rxBuffSize);
+
+void BOARD_PullCameraResetPin(bool pullUp);
+
+void BOARD_PullCameraPowerDownPin(bool pullUp);
+
+void BOARD_InitPxp(void);
+void BOARD_InitCamera(void);
+void BOARD_PxpConfig(void);
+
+uint8_t* IndexToFramebufferPtr(int index);
+int FramebufferPtrToIndex(const uint8_t* framebuffer_ptr);
+
+void CamDumpRegisters(void);
+void CamDumpRegistersOnly(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* _CAMERA_SUPPORT_H_ */

--- a/libs/nxp/rt1176-sdk/CMakeLists.txt
+++ b/libs/nxp/rt1176-sdk/CMakeLists.txt
@@ -83,6 +83,12 @@ set(libs_nxp_rt1176-sdk_SOURCES
     ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/middleware/usb/output/source/device/class/usb_device_hid.c
     ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/middleware/usb/output/source/device/usb_device_ch9.c
     ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/middleware/usb/phy/usb_phy.c
+    ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/fsl_mipi_csi2rx.c
+    ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/devices/MIMXRT1176/drivers/fsl_soc_mipi_csi2rx.c
+    ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/device/ov5640/fsl_ov5640.c
+    ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/device/sccb/fsl_sccb.c
+    ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/fsl_video_common.c
+    ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/receiver/csi/fsl_csi_camera_adapter.c
     ${libs_CMSIS_SOURCES}
 )
 
@@ -151,6 +157,13 @@ set(libs_nxp_rt1176-sdk_TARGET_INCLUDE_DIRECTORIES
     ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/middleware/usb/output/source/device
     ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/middleware/usb/output/source/device/class
     ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/middleware/usb/phy
+    ${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video
+${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera
+${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/device
+${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/device/sccb
+${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/device/ov5640
+${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/receiver
+${PROJECT_SOURCE_DIR}/third_party/nxp/rt1176-sdk/components/video/camera/receiver/csi
 )
 
 set(libs_nxp_rt1176-sdk-m7_TARGET_INCLUDE_DIRECTORIES

--- a/libs/nxp/rt1176-sdk/MIMXRT1176xxxxx_cm7_elfloader.ld
+++ b/libs/nxp/rt1176-sdk/MIMXRT1176xxxxx_cm7_elfloader.ld
@@ -50,7 +50,8 @@ MEMORY
   m_data                (RW)  : ORIGIN = 0x20000000 + NCACHE_SIZE, LENGTH = 0x00040000 - NCACHE_SIZE
   rpmsg_sh_mem          (RW)  : ORIGIN = 0x202C0000, LENGTH = RPMSG_SHMEM_SIZE
   m_heap                (RW)  : ORIGIN = 0x80000000, LENGTH = HEAP_SIZE
-  m_sdram               (RW)  : ORIGIN = 0x80000000 + HEAP_SIZE, LENGTH = 0x03000000 - HEAP_SIZE
+  m_sdram               (RW)  : ORIGIN = 0x80000000 + HEAP_SIZE, LENGTH = 0x02000000 - HEAP_SIZE
+  m_ncamera             (Rw)  : ORIGIN = 0x82000000, LENGTH = 0x01000000
 }
 
 /* Define output sections */
@@ -58,6 +59,9 @@ SECTIONS
 {
   __NCACHE_REGION_START = ORIGIN(m_ncache);
   __NCACHE_REGION_SIZE  = LENGTH(m_ncache);
+
+  __NCAMERA_REGION_START = ORIGIN(m_ncamera);
+  __NCAMERA_REGION_SIZE  = LENGTH(m_ncamera);
 
   __RPMSG_SH_MEM_START = ORIGIN(rpmsg_sh_mem);
   __RPMSG_SH_MEM_SIZE  = LENGTH(rpmsg_sh_mem);
@@ -254,6 +258,14 @@ SECTIONS
     . = ALIGN(8);
     . += STACK_SIZE;
   } > m_data
+
+  .ncamera :
+  {
+    __noncachecameradata_start__ = .;
+    *(NonCacheableCamera)
+    . = ALIGN(64);
+    __noncachecameradata_end__ = .;
+  } > m_ncamera
 
   /* Initializes stack on the end of block */
   __StackTop   = ORIGIN(m_data) + LENGTH(m_data);

--- a/libs/nxp/rt1176-sdk/MIMXRT1176xxxxx_cm7_ram.ld
+++ b/libs/nxp/rt1176-sdk/MIMXRT1176xxxxx_cm7_ram.ld
@@ -50,7 +50,8 @@ MEMORY
   m_ocram               (RX)  : ORIGIN = 0x20240000, LENGTH = 0x00080000
   rpmsg_sh_mem          (RW)  : ORIGIN = 0x202C0000, LENGTH = RPMSG_SHMEM_SIZE
   m_heap                (RW)  : ORIGIN = 0x80000000, LENGTH = HEAP_SIZE
-  m_sdram               (RX)  : ORIGIN = 0x80000000 + HEAP_SIZE, LENGTH = 0x03000000 - HEAP_SIZE
+  m_sdram               (RX)  : ORIGIN = 0x80000000 + HEAP_SIZE, LENGTH = 0x02000000 - HEAP_SIZE
+  m_ncamera             (RW)  : ORIGIN = 0x82000000, LENGTH = 0x01000000
 }
 
 /* Define output sections */
@@ -58,6 +59,9 @@ SECTIONS
 {
   __NCACHE_REGION_START = ORIGIN(m_ncache);
   __NCACHE_REGION_SIZE  = LENGTH(m_ncache);
+
+  __NCAMERA_REGION_START = ORIGIN(m_ncamera);
+  __NCAMERA_REGION_SIZE  = LENGTH(m_ncamera);
 
   __RPMSG_SH_MEM_START = ORIGIN(rpmsg_sh_mem);
   __RPMSG_SH_MEM_SIZE  = LENGTH(rpmsg_sh_mem);
@@ -450,6 +454,14 @@ SECTIONS
     . = ALIGN(8);
     . += STACK_SIZE;
   } > m_data
+
+  .ncamera :
+  {
+    __noncachecameradata_start__ = .;
+    *(NonCacheableCamera)
+    . = ALIGN(64);
+    __noncachecameradata_end__ = .;
+  } > m_ncamera
 
   /* Initializes stack on the end of block */
   __StackTop   = ORIGIN(m_data) + LENGTH(m_data);


### PR DESCRIPTION
Updated camera_streaming_http example.

Build command: bash build.sh
USB reprogramming: python3 scripts/flashtool.py -e camera_streaming_http --subapp camera_streaming_http_usb
Web browser live streaming: http://10.10.10.1/coral_micro_camera.html

PRESS user button to switch from LIVE stream to 2 test patterns streams.